### PR TITLE
tools: DrvGen: Use python2(temp)

### DIFF
--- a/tools/dct/DrvGen.py
+++ b/tools/dct/DrvGen.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2016 MediaTek Inc.


### PR DESCRIPTION
This script follows python 2.x syntax , so we force it to use python2 interpreter (it's temporary fix only and we should start working on rewriting it in python3)